### PR TITLE
Add Jitpack support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "java"
+    id 'maven-publish'
 }
 
 group "io.github.ashy1227"
@@ -29,4 +30,10 @@ jar {
 		attributes('Implementation-Title': project.name,
 				'Implementation-Version': project.version)
 	}
+}
+
+publishing{
+    repositories{
+        mavenLocal()
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ jar {
 }
 
 publishing{
+    publications{
+        recp(MavenPublication){
+            from components.java
+        }
+    }
     repositories{
         mavenLocal()
     }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+before_install:
+  - sdk install java 17.0.2-open
+  - sdk use java 17.0.2-open
+env:
+  ENVIRONMENT: "production"


### PR DESCRIPTION
This will allow for publishing releases and snapshots to Jitpack for easy use as a dependency for other projects.